### PR TITLE
BAK-1340 Add gpu metrics available in later firmware

### DIFF
--- a/cmd/idrac_gpu_exporter/testdata/content/redfish/v1/Systems/System.Embedded.1/Processors/Video.Slot.21-1/ProcessorMetrics/index.json
+++ b/cmd/idrac_gpu_exporter/testdata/content/redfish/v1/Systems/System.Embedded.1/Processors/Video.Slot.21-1/ProcessorMetrics/index.json
@@ -8,7 +8,7 @@
     "Oem": {
         "Nvidia": {
             "@odata.type": "#NvidiaProcessorMetrics.v1_3_0.ProcessorMetrics",
-            "ThrottleReasons": [],
+            "ThrottleReasons": ["Software"],
             "SMUtilizationPercent": 2913,
             "SMActivityPercent": 0.0,
             "SMOccupancyPercent": 0.0,

--- a/cmd/idrac_gpu_exporter/testdata/expected.txt
+++ b/cmd/idrac_gpu_exporter/testdata/expected.txt
@@ -28,6 +28,26 @@ idrac_gpu_consumed_power_watt{id="Video.Slot.25-1"} 78.7
 idrac_gpu_consumed_power_watt{id="Video.Slot.26-1"} 79
 idrac_gpu_consumed_power_watt{id="Video.Slot.27-1"} 80.2
 idrac_gpu_consumed_power_watt{id="Video.Slot.28-1"} 79.4
+# HELP idrac_gpu_current_pcie_link_speed Current PCIe link speed of the GPU
+# TYPE idrac_gpu_current_pcie_link_speed gauge
+idrac_gpu_current_pcie_link_speed{id="Video.Slot.21-1"} 5
+idrac_gpu_current_pcie_link_speed{id="Video.Slot.22-1"} 5
+idrac_gpu_current_pcie_link_speed{id="Video.Slot.23-1"} 5
+idrac_gpu_current_pcie_link_speed{id="Video.Slot.24-1"} 5
+idrac_gpu_current_pcie_link_speed{id="Video.Slot.25-1"} 5
+idrac_gpu_current_pcie_link_speed{id="Video.Slot.26-1"} 5
+idrac_gpu_current_pcie_link_speed{id="Video.Slot.27-1"} 5
+idrac_gpu_current_pcie_link_speed{id="Video.Slot.28-1"} 5
+# HELP idrac_gpu_dram_utilization_percent DRAM utilization of the GPU in percent
+# TYPE idrac_gpu_dram_utilization_percent gauge
+idrac_gpu_dram_utilization_percent{id="Video.Slot.21-1"} 0
+idrac_gpu_dram_utilization_percent{id="Video.Slot.22-1"} 0
+idrac_gpu_dram_utilization_percent{id="Video.Slot.23-1"} 0
+idrac_gpu_dram_utilization_percent{id="Video.Slot.24-1"} 0
+idrac_gpu_dram_utilization_percent{id="Video.Slot.25-1"} 0
+idrac_gpu_dram_utilization_percent{id="Video.Slot.26-1"} 0
+idrac_gpu_dram_utilization_percent{id="Video.Slot.27-1"} 0
+idrac_gpu_dram_utilization_percent{id="Video.Slot.28-1"} 0
 # HELP idrac_gpu_exporter_build_info Constant metric with build information for the exporter
 # TYPE idrac_gpu_exporter_build_info untyped
 idrac_gpu_exporter_build_info{goversion="go1.23.1",revision="",version=""} 1
@@ -44,6 +64,16 @@ idrac_gpu_health{id="Video.Slot.25-1",status="OK"} 2
 idrac_gpu_health{id="Video.Slot.26-1",status="OK"} 2
 idrac_gpu_health{id="Video.Slot.27-1",status="OK"} 2
 idrac_gpu_health{id="Video.Slot.28-1",status="OK"} 2
+# HELP idrac_gpu_hmma_utilization_percent HMMA (Hybrid Matrix Multiply-Accumulate) utilization of the GPU in percent
+# TYPE idrac_gpu_hmma_utilization_percent gauge
+idrac_gpu_hmma_utilization_percent{id="Video.Slot.21-1"} 0
+idrac_gpu_hmma_utilization_percent{id="Video.Slot.22-1"} 0
+idrac_gpu_hmma_utilization_percent{id="Video.Slot.23-1"} 0
+idrac_gpu_hmma_utilization_percent{id="Video.Slot.24-1"} 0
+idrac_gpu_hmma_utilization_percent{id="Video.Slot.25-1"} 0
+idrac_gpu_hmma_utilization_percent{id="Video.Slot.26-1"} 0
+idrac_gpu_hmma_utilization_percent{id="Video.Slot.27-1"} 0
+idrac_gpu_hmma_utilization_percent{id="Video.Slot.28-1"} 0
 # HELP idrac_gpu_info Information about the GPU
 # TYPE idrac_gpu_info untyped
 idrac_gpu_info{id="Video.Slot.21-1",manufacturer="NVIDIA Corporation",model="NVIDIA H200",part_number="692-2G520-0280-001",serial_number="1653824200703",uuid="7bc0e864ac5e6f1f3f4e468d8cb72eae"} 1
@@ -54,6 +84,16 @@ idrac_gpu_info{id="Video.Slot.25-1",manufacturer="NVIDIA Corporation",model="NVI
 idrac_gpu_info{id="Video.Slot.26-1",manufacturer="NVIDIA Corporation",model="NVIDIA H200",part_number="692-2G520-0280-001",serial_number="1653824201536",uuid="32b85d9d4df56ec25a71d4db2899d6a2"} 1
 idrac_gpu_info{id="Video.Slot.27-1",manufacturer="NVIDIA Corporation",model="NVIDIA H200",part_number="692-2G520-0280-001",serial_number="1653824200527",uuid="0d77eb8e940575e1cdb2915b31964481"} 1
 idrac_gpu_info{id="Video.Slot.28-1",manufacturer="NVIDIA Corporation",model="NVIDIA H200",part_number="692-2G520-0280-001",serial_number="1653824201434",uuid="6108731b5ec3d248596ef5927e9dab51"} 1
+# HELP idrac_gpu_max_supported_pcie_link_speed Maximum supported PCIe link speed of the GPU
+# TYPE idrac_gpu_max_supported_pcie_link_speed gauge
+idrac_gpu_max_supported_pcie_link_speed{id="Video.Slot.21-1"} 5
+idrac_gpu_max_supported_pcie_link_speed{id="Video.Slot.22-1"} 5
+idrac_gpu_max_supported_pcie_link_speed{id="Video.Slot.23-1"} 5
+idrac_gpu_max_supported_pcie_link_speed{id="Video.Slot.24-1"} 5
+idrac_gpu_max_supported_pcie_link_speed{id="Video.Slot.25-1"} 5
+idrac_gpu_max_supported_pcie_link_speed{id="Video.Slot.26-1"} 5
+idrac_gpu_max_supported_pcie_link_speed{id="Video.Slot.27-1"} 5
+idrac_gpu_max_supported_pcie_link_speed{id="Video.Slot.28-1"} 5
 # HELP idrac_gpu_memory_bandwidth_percent Utilization of the GPU memory in percent
 # TYPE idrac_gpu_memory_bandwidth_percent gauge
 idrac_gpu_memory_bandwidth_percent{id="Video.Slot.21-1"} 0
@@ -94,6 +134,36 @@ idrac_gpu_operating_speed_mhz{id="Video.Slot.25-1"} 345
 idrac_gpu_operating_speed_mhz{id="Video.Slot.26-1"} 345
 idrac_gpu_operating_speed_mhz{id="Video.Slot.27-1"} 345
 idrac_gpu_operating_speed_mhz{id="Video.Slot.28-1"} 345
+# HELP idrac_gpu_pcie_correctable_error_count Number of correctable PCIe errors of the GPU
+# TYPE idrac_gpu_pcie_correctable_error_count counter
+idrac_gpu_pcie_correctable_error_count{id="Video.Slot.21-1"} 0
+idrac_gpu_pcie_correctable_error_count{id="Video.Slot.22-1"} 0
+idrac_gpu_pcie_correctable_error_count{id="Video.Slot.23-1"} 0
+idrac_gpu_pcie_correctable_error_count{id="Video.Slot.24-1"} 0
+idrac_gpu_pcie_correctable_error_count{id="Video.Slot.25-1"} 0
+idrac_gpu_pcie_correctable_error_count{id="Video.Slot.26-1"} 0
+idrac_gpu_pcie_correctable_error_count{id="Video.Slot.27-1"} 0
+idrac_gpu_pcie_correctable_error_count{id="Video.Slot.28-1"} 0
+# HELP idrac_gpu_pcie_raw_rx_bandwidth_gbps PCIe raw receive bandwidth of the GPU in Gbps
+# TYPE idrac_gpu_pcie_raw_rx_bandwidth_gbps gauge
+idrac_gpu_pcie_raw_rx_bandwidth_gbps{id="Video.Slot.21-1"} 0
+idrac_gpu_pcie_raw_rx_bandwidth_gbps{id="Video.Slot.22-1"} 0
+idrac_gpu_pcie_raw_rx_bandwidth_gbps{id="Video.Slot.23-1"} 0
+idrac_gpu_pcie_raw_rx_bandwidth_gbps{id="Video.Slot.24-1"} 0
+idrac_gpu_pcie_raw_rx_bandwidth_gbps{id="Video.Slot.25-1"} 0
+idrac_gpu_pcie_raw_rx_bandwidth_gbps{id="Video.Slot.26-1"} 0
+idrac_gpu_pcie_raw_rx_bandwidth_gbps{id="Video.Slot.27-1"} 0
+idrac_gpu_pcie_raw_rx_bandwidth_gbps{id="Video.Slot.28-1"} 0
+# HELP idrac_gpu_pcie_raw_tx_bandwidth_gbps PCIe raw transmit bandwidth of the GPU in Gbps
+# TYPE idrac_gpu_pcie_raw_tx_bandwidth_gbps gauge
+idrac_gpu_pcie_raw_tx_bandwidth_gbps{id="Video.Slot.21-1"} 0
+idrac_gpu_pcie_raw_tx_bandwidth_gbps{id="Video.Slot.22-1"} 0
+idrac_gpu_pcie_raw_tx_bandwidth_gbps{id="Video.Slot.23-1"} 0
+idrac_gpu_pcie_raw_tx_bandwidth_gbps{id="Video.Slot.24-1"} 0
+idrac_gpu_pcie_raw_tx_bandwidth_gbps{id="Video.Slot.25-1"} 0
+idrac_gpu_pcie_raw_tx_bandwidth_gbps{id="Video.Slot.26-1"} 0
+idrac_gpu_pcie_raw_tx_bandwidth_gbps{id="Video.Slot.27-1"} 0
+idrac_gpu_pcie_raw_tx_bandwidth_gbps{id="Video.Slot.28-1"} 0
 # HELP idrac_gpu_power_brake_status Status of the GPU power brake
 # TYPE idrac_gpu_power_brake_status gauge
 idrac_gpu_power_brake_status{id="Video.Slot.21-1",status="Released"} 1
@@ -114,6 +184,36 @@ idrac_gpu_primary_gpu_temperature_celsius{id="Video.Slot.25-1"} 40
 idrac_gpu_primary_gpu_temperature_celsius{id="Video.Slot.26-1"} 38
 idrac_gpu_primary_gpu_temperature_celsius{id="Video.Slot.27-1"} 40
 idrac_gpu_primary_gpu_temperature_celsius{id="Video.Slot.28-1"} 38
+# HELP idrac_gpu_sm_activity_percent Streaming Multiprocessor (SM) activity of the GPU in percent
+# TYPE idrac_gpu_sm_activity_percent gauge
+idrac_gpu_sm_activity_percent{id="Video.Slot.21-1"} 0
+idrac_gpu_sm_activity_percent{id="Video.Slot.22-1"} 0
+idrac_gpu_sm_activity_percent{id="Video.Slot.23-1"} 0
+idrac_gpu_sm_activity_percent{id="Video.Slot.24-1"} 0
+idrac_gpu_sm_activity_percent{id="Video.Slot.25-1"} 0
+idrac_gpu_sm_activity_percent{id="Video.Slot.26-1"} 0
+idrac_gpu_sm_activity_percent{id="Video.Slot.27-1"} 0
+idrac_gpu_sm_activity_percent{id="Video.Slot.28-1"} 0
+# HELP idrac_gpu_sm_occupancy_percent Streaming Multiprocessor (SM) occupancy of the GPU in percent
+# TYPE idrac_gpu_sm_occupancy_percent gauge
+idrac_gpu_sm_occupancy_percent{id="Video.Slot.21-1"} 0
+idrac_gpu_sm_occupancy_percent{id="Video.Slot.22-1"} 0
+idrac_gpu_sm_occupancy_percent{id="Video.Slot.23-1"} 0
+idrac_gpu_sm_occupancy_percent{id="Video.Slot.24-1"} 0
+idrac_gpu_sm_occupancy_percent{id="Video.Slot.25-1"} 0
+idrac_gpu_sm_occupancy_percent{id="Video.Slot.26-1"} 0
+idrac_gpu_sm_occupancy_percent{id="Video.Slot.27-1"} 0
+idrac_gpu_sm_occupancy_percent{id="Video.Slot.28-1"} 0
+# HELP idrac_gpu_sm_utilization_percent Streaming Multiprocessor (SM) utilization of the GPU in percent
+# TYPE idrac_gpu_sm_utilization_percent gauge
+idrac_gpu_sm_utilization_percent{id="Video.Slot.21-1"} 2913
+idrac_gpu_sm_utilization_percent{id="Video.Slot.22-1"} 2924
+idrac_gpu_sm_utilization_percent{id="Video.Slot.23-1"} 2901
+idrac_gpu_sm_utilization_percent{id="Video.Slot.24-1"} 2898
+idrac_gpu_sm_utilization_percent{id="Video.Slot.25-1"} 2912
+idrac_gpu_sm_utilization_percent{id="Video.Slot.26-1"} 2921
+idrac_gpu_sm_utilization_percent{id="Video.Slot.27-1"} 2904
+idrac_gpu_sm_utilization_percent{id="Video.Slot.28-1"} 2899
 # HELP idrac_gpu_state State of the GPU
 # TYPE idrac_gpu_state gauge
 idrac_gpu_state{id="Video.Slot.21-1",state="Available"} 0
@@ -124,6 +224,16 @@ idrac_gpu_state{id="Video.Slot.25-1",state="Available"} 0
 idrac_gpu_state{id="Video.Slot.26-1",state="Available"} 0
 idrac_gpu_state{id="Video.Slot.27-1",state="Available"} 0
 idrac_gpu_state{id="Video.Slot.28-1",state="Available"} 0
+# HELP idrac_gpu_tensor_core_activity_percent Tensor Core activity of the GPU in percent
+# TYPE idrac_gpu_tensor_core_activity_percent gauge
+idrac_gpu_tensor_core_activity_percent{id="Video.Slot.21-1"} 0
+idrac_gpu_tensor_core_activity_percent{id="Video.Slot.22-1"} 0
+idrac_gpu_tensor_core_activity_percent{id="Video.Slot.23-1"} 0
+idrac_gpu_tensor_core_activity_percent{id="Video.Slot.24-1"} 0
+idrac_gpu_tensor_core_activity_percent{id="Video.Slot.25-1"} 0
+idrac_gpu_tensor_core_activity_percent{id="Video.Slot.26-1"} 0
+idrac_gpu_tensor_core_activity_percent{id="Video.Slot.27-1"} 0
+idrac_gpu_tensor_core_activity_percent{id="Video.Slot.28-1"} 0
 # HELP idrac_gpu_thermal_alert_status Thermal alert status of the GPU
 # TYPE idrac_gpu_thermal_alert_status gauge
 idrac_gpu_thermal_alert_status{id="Video.Slot.21-1",status="NotPending"} 1
@@ -134,3 +244,6 @@ idrac_gpu_thermal_alert_status{id="Video.Slot.25-1",status="NotPending"} 1
 idrac_gpu_thermal_alert_status{id="Video.Slot.26-1",status="NotPending"} 1
 idrac_gpu_thermal_alert_status{id="Video.Slot.27-1",status="NotPending"} 1
 idrac_gpu_thermal_alert_status{id="Video.Slot.28-1",status="NotPending"} 1
+# HELP idrac_gpu_throttle_reason Reason for GPU throttling
+# TYPE idrac_gpu_throttle_reason gauge
+idrac_gpu_throttle_reason{id="Video.Slot.21-1",reason="Software"} 1

--- a/internal/collector/client.go
+++ b/internal/collector/client.go
@@ -186,17 +186,29 @@ func (client *Client) RefreshGPUs(mc *Collector, ch chan<- prometheus.Metric) bo
 			mc.NewGPUConsumedPowerWatt(ch, &gpuMetrics)
 			mc.NewGPUOperatingSpeedMHz(ch, &gpuMetrics)
 
-			// // NVIDIA
-            // TODO: check this
+			if gpuMetrics.Oem != nil {
+				nvidia := gpuMetrics.Oem.Nvidia
+				if nvidia != nil {
+					mc.NewGPUThrottleReasons(ch, nvidia.ThrottleReasons, gpuMetrics.Id)
+					mc.NewGPUSMUtilizationPercent(ch, nvidia.SMUtilizationPercent, gpuMetrics.Id)
+					mc.NewGPUSMActivityPercent(ch, nvidia.SMActivityPercent, gpuMetrics.Id)
+					mc.NewGPUSMOccupancyPercent(ch, nvidia.SMOccupancyPercent, gpuMetrics.Id)
+					mc.NewGPUTensorCoreActivityPercent(ch, nvidia.TensorCoreActivityPercent, gpuMetrics.Id)
+					mc.NewGPUHMMAUtilizationPercent(ch, nvidia.HMMAUtilizationPercent, gpuMetrics.Id)
+					mc.NewGPUPCIeRawTxBandwidthGbps(ch, nvidia.PCIeRawTxBandwidthGbps, gpuMetrics.Id)
+					mc.NewGPUPCIeRawRxBandwidthGbps(ch, nvidia.PCIeRawRxBandwidthGbps, gpuMetrics.Id)
+				}
+				dell := gpuMetrics.Oem.Dell
+				if dell != nil {
+					mc.NewGPUCurrentPCIeLinkSpeed(ch, dell.CurrentPCIeLinkSpeed, gpuMetrics.Id)
+					mc.NewGPUMaxSupportedPCIeLinkSpeed(ch, dell.MaxSupportedPCIeLinkSpeed, gpuMetrics.Id)
+					mc.NewGPUDRAMUtilizationPercent(ch, dell.DRAMUtilizationPercent, gpuMetrics.Id)
+				}
+			}
 
-			// if metrics.Oem.Nvidia != nil {
-			// 	mc.NewGPUUtilization(ch, metrics.Oem.Nvidia.UtilizationPercentage, resp.Id)
-			// 	mc.NewGPUTemperature(ch, metrics.Oem.Nvidia.TemperatureCelsius, resp.Id)
-			// 	mc.NewGPUMemoryTotal(ch, float64(metrics.Oem.Nvidia.MemoryTotalMiB*1024*1024), resp.Id)
-			// 	mc.NewGPUMemoryUsed(ch, float64(metrics.Oem.Nvidia.MemoryUsedMiB*1024*1024), resp.Id)
-			// 	mc.NewGPUMemoryFree(ch, float64(metrics.Oem.Nvidia.MemoryFreeMiB*1024*1024), resp.Id)
-			// 	mc.NewGPUMemoryUtilization(ch, metrics.Oem.Nvidia.MemoryUtilizationPercentage, resp.Id)
-			// }
+			if gpuMetrics.PCIeErrors != nil {
+				mc.NewGPUPCIeCorrectableErrorCount(ch, gpuMetrics.PCIeErrors.CorrectableErrorCount, gpuMetrics.Id)
+			}
 		}
 
 		if resp.MemorySummary.Metrics.OdataId != "" {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -31,19 +31,31 @@ type Collector struct {
 	ExporterScrapeErrorsTotal *prometheus.Desc
 
 	// GPUs
-	GPUInfo         *prometheus.Desc
-	GPUState        *prometheus.Desc 
-	GPUHealth       *prometheus.Desc
+	GPUInfo                         *prometheus.Desc
+	GPUState                        *prometheus.Desc
+	GPUHealth                       *prometheus.Desc
 	GPUBoardPowerSupplyStatus       *prometheus.Desc
-	GPUMemoryTemperatureCelsius       *prometheus.Desc
-	GPUPowerBrakeStatus       *prometheus.Desc
-	GPUPrimaryGPUTemperatureCelsius       *prometheus.Desc
-	GPUThermalAlertStatus       *prometheus.Desc
-	GPUBandwidthPercent       *prometheus.Desc
-	GPUConsumedPowerWatt      *prometheus.Desc
-	GPUOperatingSpeedMHz       *prometheus.Desc
+	GPUMemoryTemperatureCelsius     *prometheus.Desc
+	GPUPowerBrakeStatus             *prometheus.Desc
+	GPUPrimaryGPUTemperatureCelsius *prometheus.Desc
+	GPUThermalAlertStatus           *prometheus.Desc
+	GPUBandwidthPercent             *prometheus.Desc
+	GPUConsumedPowerWatt            *prometheus.Desc
+	GPUOperatingSpeedMHz            *prometheus.Desc
 	GPUMemoryBandwidthPercent       *prometheus.Desc
-	GPUMemoryOperatingSpeedMHz       *prometheus.Desc
+	GPUMemoryOperatingSpeedMHz      *prometheus.Desc
+	GPUThrottleReason               *prometheus.Desc
+	GPUSMUtilizationPercent         *prometheus.Desc
+	GPUSMActivityPercent            *prometheus.Desc
+	GPUSMOccupancyPercent           *prometheus.Desc
+	GPUTensorCoreActivityPercent    *prometheus.Desc
+	GPUHMMAUtilizationPercent       *prometheus.Desc
+	GPUPCIeRawTxBandwidthGbps       *prometheus.Desc
+	GPUPCIeRawRxBandwidthGbps       *prometheus.Desc
+	GPUCurrentPCIeLinkSpeed         *prometheus.Desc
+	GPUMaxSupportedPCIeLinkSpeed    *prometheus.Desc
+	GPUDRAMUtilizationPercent       *prometheus.Desc
+	GPUPCIeCorrectableErrorCount    *prometheus.Desc
 }
 
 func NewCollector() *Collector {
@@ -129,6 +141,66 @@ func NewCollector() *Collector {
 			"Operating speed of the GPU memory in Mhz",
 			[]string{"id"}, nil,
 		),
+		GPUThrottleReason: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "throttle_reason"),
+			"Reason for GPU throttling",
+			[]string{"id", "reason"}, nil,
+		),
+		GPUSMUtilizationPercent: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "sm_utilization_percent"),
+			"Streaming Multiprocessor (SM) utilization of the GPU in percent",
+			[]string{"id"}, nil,
+		),
+		GPUSMActivityPercent: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "sm_activity_percent"),
+			"Streaming Multiprocessor (SM) activity of the GPU in percent",
+			[]string{"id"}, nil,
+		),
+		GPUSMOccupancyPercent: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "sm_occupancy_percent"),
+			"Streaming Multiprocessor (SM) occupancy of the GPU in percent",
+			[]string{"id"}, nil,
+		),
+		GPUTensorCoreActivityPercent: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "tensor_core_activity_percent"),
+			"Tensor Core activity of the GPU in percent",
+			[]string{"id"}, nil,
+		),
+		GPUHMMAUtilizationPercent: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "hmma_utilization_percent"),
+			"HMMA (Hybrid Matrix Multiply-Accumulate) utilization of the GPU in percent",
+			[]string{"id"}, nil,
+		),
+		GPUPCIeRawTxBandwidthGbps: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "pcie_raw_tx_bandwidth_gbps"),
+			"PCIe raw transmit bandwidth of the GPU in Gbps",
+			[]string{"id"}, nil,
+		),
+		GPUPCIeRawRxBandwidthGbps: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "pcie_raw_rx_bandwidth_gbps"),
+			"PCIe raw receive bandwidth of the GPU in Gbps",
+			[]string{"id"}, nil,
+		),
+		GPUCurrentPCIeLinkSpeed: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "current_pcie_link_speed"),
+			"Current PCIe link speed of the GPU",
+			[]string{"id"}, nil,
+		),
+		GPUMaxSupportedPCIeLinkSpeed: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "max_supported_pcie_link_speed"),
+			"Maximum supported PCIe link speed of the GPU",
+			[]string{"id"}, nil,
+		),
+		GPUDRAMUtilizationPercent: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "dram_utilization_percent"),
+			"DRAM utilization of the GPU in percent",
+			[]string{"id"}, nil,
+		),
+		GPUPCIeCorrectableErrorCount: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "gpu", "pcie_correctable_error_count"),
+			"Number of correctable PCIe errors of the GPU",
+			[]string{"id"}, nil,
+		),
 	}
 
 	collector.builder = new(strings.Builder)
@@ -155,6 +227,18 @@ func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.GPUOperatingSpeedMHz
 	ch <- collector.GPUMemoryBandwidthPercent
 	ch <- collector.GPUMemoryOperatingSpeedMHz
+	ch <- collector.GPUThrottleReason
+	ch <- collector.GPUSMUtilizationPercent
+	ch <- collector.GPUSMActivityPercent
+	ch <- collector.GPUSMOccupancyPercent
+	ch <- collector.GPUTensorCoreActivityPercent
+	ch <- collector.GPUHMMAUtilizationPercent
+	ch <- collector.GPUPCIeRawTxBandwidthGbps
+	ch <- collector.GPUPCIeRawRxBandwidthGbps
+	ch <- collector.GPUCurrentPCIeLinkSpeed
+	ch <- collector.GPUMaxSupportedPCIeLinkSpeed
+	ch <- collector.GPUDRAMUtilizationPercent
+	ch <- collector.GPUPCIeCorrectableErrorCount
 }
 
 func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
@@ -206,7 +290,6 @@ func (collector *Collector) Gather() (string, error) {
 			log.Printf("Error converting metric to text: %v", err)
 		}
 	}
-
 
 	return collector.builder.String(), nil
 }

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -166,19 +166,137 @@ func (mc *Collector) NewThermalAlertStatus(ch chan<- prometheus.Metric, m *DellG
 }
 
 func (mc *Collector) NewGPUOperatingSpeedMHz(ch chan<- prometheus.Metric, m *GPUMetrics) {
+	if m.OperatingSpeedMHz == nil {
+		return
+	}
 	ch <- prometheus.MustNewConstMetric(
 		mc.GPUOperatingSpeedMHz,
 		prometheus.GaugeValue,
-		m.OperatingSpeedMHz,
+		*m.OperatingSpeedMHz,
 		m.Id,
 	)
 }
 
+func (mc *Collector) NewGPUThrottleReasons(ch chan<- prometheus.Metric, v []string , id string) {
+	for _, reason := range v {
+		// TODO: default all possible reason metrics to zero when known
+		ch <- prometheus.MustNewConstMetric(
+			mc.GPUThrottleReason,
+			prometheus.GaugeValue,
+			1.0,
+			id,
+			reason,
+		)
+	}
+}
+
+func (mc *Collector) NewGPUSMUtilizationPercent(ch chan<- prometheus.Metric, v int , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUSMUtilizationPercent,
+		prometheus.GaugeValue,
+		float64(v),
+		id,
+	)
+}
+
+func (mc *Collector) NewGPUSMActivityPercent(ch chan<- prometheus.Metric, v float64 , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUSMActivityPercent,
+		prometheus.GaugeValue,
+		v,
+		id,
+	)
+}
+
+func (mc *Collector) NewGPUSMOccupancyPercent(ch chan<- prometheus.Metric, v float64 , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUSMOccupancyPercent,
+		prometheus.GaugeValue,
+		v,
+		id,
+	)
+}
+
+func (mc *Collector) NewGPUTensorCoreActivityPercent(ch chan<- prometheus.Metric, v float64 , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUTensorCoreActivityPercent,
+		prometheus.GaugeValue,
+		v,
+		id,
+	)
+}
+
+func (mc *Collector) NewGPUHMMAUtilizationPercent(ch chan<- prometheus.Metric, v float64 , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUHMMAUtilizationPercent,
+		prometheus.GaugeValue,
+		v,
+		id,
+	)
+}
+
+func (mc *Collector) NewGPUPCIeRawTxBandwidthGbps(ch chan<- prometheus.Metric, v float64 , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUPCIeRawTxBandwidthGbps,
+		prometheus.GaugeValue,
+		v,
+		id,
+	)
+}
+
+func (mc *Collector) NewGPUPCIeRawRxBandwidthGbps(ch chan<- prometheus.Metric, v float64 , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUPCIeRawRxBandwidthGbps,
+		prometheus.GaugeValue,
+		v,
+		id,
+	)
+}
+
+func (mc *Collector) NewGPUCurrentPCIeLinkSpeed(ch chan<- prometheus.Metric, v int , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUCurrentPCIeLinkSpeed,
+		prometheus.GaugeValue,
+		float64(v),
+		id,
+	)
+}
+
+func (mc *Collector) NewGPUMaxSupportedPCIeLinkSpeed(ch chan<- prometheus.Metric, v int , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUMaxSupportedPCIeLinkSpeed,
+		prometheus.GaugeValue,
+		float64(v),
+		id,
+	)
+}
+
+func (mc *Collector) NewGPUDRAMUtilizationPercent(ch chan<- prometheus.Metric, v float64 , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUDRAMUtilizationPercent,
+		prometheus.GaugeValue,
+		v,
+		id,
+	)
+}
+
+func (mc *Collector) NewGPUPCIeCorrectableErrorCount(ch chan<- prometheus.Metric, v int , id string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.GPUPCIeCorrectableErrorCount,
+		prometheus.CounterValue,
+		float64(v),
+		id,
+	)
+}
+
 func (mc *Collector) NewGPUBandwidthPercent(ch chan<- prometheus.Metric, m *GPUMetrics) {
+	if m.BandwidthPercent == nil {
+		return
+	}
 	ch <- prometheus.MustNewConstMetric(
 		mc.GPUBandwidthPercent,
 		prometheus.GaugeValue,
-		m.BandwidthPercent,
+		*m.BandwidthPercent,
 		m.Id,
 	)
 }

--- a/internal/collector/model.go
+++ b/internal/collector/model.go
@@ -165,9 +165,30 @@ type GPUMetrics struct {
 	Id                    string  `json:"Id"`
     TemperatureCelsius	  float64 `json:"TemperatureCelsius"`
     ConsumedPowerWatt 	  float64 `json:"ConsumedPowerWatt"`
-    OperatingSpeedMHz	  float64 `json:"OperatingSpeedMHz"`
-    BandwidthPercent      float64 `json:"BandwidthPercent"`
+    OperatingSpeedMHz	  *float64 `json:"OperatingSpeedMHz"`
+    BandwidthPercent      *float64 `json:"BandwidthPercent"`
+	Oem				   *struct {
+		Nvidia *struct {
+			ThrottleReasons			   []string `json:"ThrottleReasons"`
+			SMUtilizationPercent	   int      `json:"SMUtilizationPercent"`
+			SMActivityPercent		   float64  `json:"SMActivityPercent"`
+			SMOccupancyPercent		   float64  `json:"SMOccupancyPercent"`
+			TensorCoreActivityPercent   float64  `json:"TensorCoreActivityPercent"`
+			HMMAUtilizationPercent	   float64  `json:"HMMAUtilizationPercent"`
+			PCIeRawTxBandwidthGbps	   float64  `json:"PCIeRawTxBandwidthGbps"`
+			PCIeRawRxBandwidthGbps	   float64  `json:"PCIeRawRxBandwidthGbps"`
+		} `json:"Nvidia"`
+		Dell *struct {
+			CurrentPCIeLinkSpeed     int     `json:"CurrentPCIeLinkSpeed"`
+			MaxSupportedPCIeLinkSpeed int     `json:"MaxSupportedPCIeLinkSpeed"`
+			DRAMUtilizationPercent    float64 `json:"DRAMUtilizationPercent"`
+		} `json:"Dell"`
+	} `json:"Oem"`
+	PCIeErrors *struct {
+		CorrectableErrorCount int `json:"CorrectableErrorCount"`
+	} `json:"PCIeErrors"`
 }
+ 
 
 type GPUMemoryMetrics struct {
     BandwidthPercent	  float64 `json:"BandwidthPercent"`


### PR DESCRIPTION
## Background

Add GPU metrics available in later firmware

## What has changed

Add the following new metrics:

idrac_gpu_throttle_reason{id, reason}
idrac_gpu_sm_utilization_percent{id}
idrac_gpu_sm_activity_percent{id}
idrac_gpu_sm_occupancy_percent{id}
idrac_gpu_tensor_core_activity_percent{id}
idrac_gpu_hmma_utilization_percent{id}
idrac_gpu_pcie_raw_tx_bandwidth_gpbs{id}
idrac_gpu_pcie_raw_rx_bandwidth_gbps{id}
idrac_gpu_current_pcie_link_speed{id}
idrac_gpu_max_supported_pcie_link_speed{id}
idrac_gpu_dram_utilization_percent{id}
idrac_gpu_pcie_correctable_error_count{id}

## How to review

Confirm tests run successfully (PR check below)
